### PR TITLE
Use slim debian image to reduce size of container

### DIFF
--- a/2.3.20/Dockerfile
+++ b/2.3.20/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:11-slim
 
 LABEL org.opencontainers.image.authors="dovecot@dovecot.org"
 


### PR DESCRIPTION
60+ MB size savings on my system.

Current build:
`docker.io/dovecot/dovecot  latest         7cbf2c69420e  8 hours ago    184 MB`

Build with bullseye-slim:
`localhost/dovecot-test     latest         c761e06a8200  6 minutes ago  119 MB`