### PR TITLE
fix: Remove VOLUME directive from Dockerfile

### DIFF
--- a/2.4.2/Dockerfile
+++ b/2.4.2/Dockerfile
@@ -193,7 +193,7 @@ RUN apt-get -y update && \
  rm -rf /etc/dovecot && \
  rm -rf /var/lib/apt/lists && \
  groupadd -g $VMAIL_GID vmail && \
- useradd -u $VMAIL_UID -g vmail -G ssl-cert -d /srv/mail -s /bin/sh vmail && \
+ useradd -u $VMAIL_UID -g vmail -G ssl-cert -d /nonexistent -s /bin/sh vmail && \
  passwd -l vmail && \
  mkdir -p /run && \
  chmod 1777 /run && \
@@ -325,6 +325,6 @@ EXPOSE 34190
 EXPOSE 8080
 EXPOSE 9090
 USER vmail
-VOLUME ["/srv/mail"]
+VOLUME ["/srv/vmail"]
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/dovecot/sbin/dovecot", "-F"]


### PR DESCRIPTION
I'd like to suggest to remove both `VOLUME` directives from the non production build stages.
The `VOLUME` directive creates and mounts directories when creating a container.  This is not always wanted, especially when using the image as a base.

See also:
- https://github.com/moby/moby/issues/3465#issuecomment-2179958180
- https://github.com/moby/buildkit/issues/4802#issuecomment-2182544924
- https://github.com/jeboehm/docker-mailserver/issues/652
-