### PR TITLE
Add dovecot and dovenull user to standard image

### DIFF
--- a/2.4.2/Dockerfile
+++ b/2.4.2/Dockerfile
@@ -195,6 +195,10 @@ RUN apt-get -y update && \
  groupadd -g $VMAIL_GID vmail && \
  useradd -u $VMAIL_UID -g vmail -G ssl-cert -d /nonexistent -s /bin/sh vmail && \
  passwd -l vmail && \
+ groupadd --system dovecot && \
+ groupadd --system dovenull && \
+ useradd -g dovecot --system dovecot && \
+ useradd -g dovenull --system dovenull && \
  mkdir -p /run && \
  chmod 1777 /run && \
  mkdir /etc/dovecot && \
@@ -220,11 +224,7 @@ ENV container=docker \
     PATH=$PATH:/dovecot/bin:/dovecot/sbin
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN groupadd --system dovecot && \
- groupadd --system dovenull && \
- useradd -g dovecot --system dovecot && \
- useradd -g dovenull --system dovenull && \
- make-ssl-cert generate-default-snakeoil && \
+RUN make-ssl-cert generate-default-snakeoil && \
  ln -s /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/dovecot/ssl/tls.crt && \
  ln -s /etc/ssl/private/ssl-cert-snakeoil.key /etc/dovecot/ssl/tls.key && \
  chown root:dovecot /etc/dovecot/ssl/tls.key && \


### PR DESCRIPTION
Dovecot uses these as default config values and sometimes checks them even before applying config overwrites.

The problem can be seen when enabeling the inet lmtp listener as shown [in the dovecot documentation](https://doc.dovecot.org/2.4.2/core/config/delivery/lmtp.html#listeners): Create a file `test.conf`:
```
protocols {
  lmtp = yes
}

service lmtp {
  inet_listener lmtp {
    listen = 192.168.0.24 127.0.0.1 ::1
    port = 24
  }

  unix_listener lmtp {
    #mode = 0666
  }
}
```
Run `docker run --rm -v ./test.conf:/etc/dovecot/conf.d/test.conf:ro dovecot/dovecot`, observe the following error message:
`doveconf: Fatal: Error in configuration file /etc/dovecot/dovecot.conf: default_login_user doesn't exist: dovenull`

This happens even though the `default_login_user` is set to `vmail` by the `rootless.conf`. This can be seen by running `docker run --rm -v ./test.conf:/etc/dovecot/conf.d/test.conf:ro dovecot/dovecot doveconf -n | grep 'default_'`:
```
doveconf: Error: default_login_user doesn't exist: dovenull
doveconf: Fatal: Error in configuration file /etc/dovecot/dovecot.conf: default_login_user doesn't exist: dovenull
default_internal_group = vmail
default_internal_user = vmail
default_login_user = vmail
```

Apparently this seems to be somewhat expected behaviour according to [this conversation](https://www.mail-archive.com/dovecot%40dovecot.org/msg92370.html).